### PR TITLE
Don't rename the bundle by default (opt-in)

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ elixir.extend('browserify', function (src, outputDir, options) {
     var config = this,
         defaultOptions = {
             debug:         ! config.production,
-            rename:        "bundle.js",
+            rename:        null,
             srcDir:        config.assetsDir + 'js',
             output:        outputDir || config.jsOutput,
             transform:     [],
@@ -40,7 +40,7 @@ elixir.extend('browserify', function (src, outputDir, options) {
         return gulp.src(src)
             .pipe(browserified).on('error', onError)
             .pipe(gulpIf(! options.debug, uglify()))
-            .pipe(rename(options.rename))
+            .pipe(gulpIf(typeof options.rename === 'string', rename(options.rename)))
             .pipe(gulp.dest(options.output))
             .pipe(new notifications().message('Browserified!'));
     });


### PR DESCRIPTION
I know this is a breaking change, but I think it makes the extension much more fluent.

Instead of the following mess...

```javascript
mix.browserify('app.js', 'public/js', { rename: 'app.js' });
```

You can simply put...

```js
mix.browserify('app.js');
```

Or even...

```js
mix.browserify('*.js');
```

But if necessary, you can manually provide whatever filename you need (maintaining existing functionality).