### PR TITLE
Added in require and external functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,9 @@ elixir.extend('browserify', function (src, options) {
         var browserified = function(filename) {
             var b = browserify(filename, options);
             
+            if(options.require) b.require(options.require);
+            if(options.external) b.external(options.external);
+            
             return b.bundle();
         };
 


### PR DESCRIPTION
Unfortunately passing in "require" and "external" into the standard options hash doesn't work with browserify. Instead I've modified the browserified function to add them inline if set via the options hash.