### PR TITLE
Multiple bundles and watchify (without changing method signatures)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+/.idea

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ elixir(function(mix) {
     });
 });
 ```
+#### Watchify
+```javascript
+var elixir = require('laravel-elixir');
+require('laravel-elixir-browserify');
+
+elixir(function(mix) {
+    mix.browserify("bootstrap.js")
+        .watchify();
+});
+```
+**Note** instead of running the `watch` task, you will now run `watchify`. Elixir's watch task is a dependency of watchify and will also be run.
 
 ## Changelog
 __0.6.0__

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp'),
     elixir = require('laravel-elixir'),
+    inSequence = require('run-sequence'),
     utilities = require('laravel-elixir/ingredients/commands/Utilities'),
     notifications = require('laravel-elixir/ingredients/commands/Notification'),
     gulpIf = require('gulp-if'),
@@ -8,6 +9,7 @@ var gulp = require('gulp'),
     source = require('vinyl-source-stream'),
     buffer = require('vinyl-buffer'),
     browserify = require('browserify'),
+    watchify = require('watchify'),
     _  = require('underscore');
 
 elixir.extend('browserify', function (src, options) {
@@ -19,7 +21,7 @@ elixir.extend('browserify', function (src, options) {
             srcDir:        config.assetsDir + 'js',
             output:        config.jsOutput,
             transform:     [],
-            insertGlobals: false,
+            insertGlobals: false
         };
 
     options = _.extend(defaultOptions, options);
@@ -32,22 +34,49 @@ elixir.extend('browserify', function (src, options) {
             this.emit('end');
         };
 
-        var browserified = function(filename) {
-            var b = browserify(filename, options);
-            
-            return b.bundle();
-        };
+        var bundle = function(b) {
+            return b.bundle()
+                .on('error', onError)
+                .pipe(source(src.split("/").pop()))
+                .pipe(buffer())
+                .pipe(gulpIf(!options.debug, uglify()))
+                .pipe(gulpIf(typeof options.rename === 'string', rename(options.rename)))
+                .pipe(gulp.dest(options.output))
+                .pipe(new notifications().message('Browserified!'));
+        }
 
-        return browserified(src).on('error', onError)
-            .pipe(source(src.split("/").pop()))
-            .pipe(buffer())
-            .pipe(gulpIf(! options.debug, uglify()))
-            .pipe(gulpIf(typeof options.rename === 'string', rename(options.rename)))
-            .pipe(gulp.dest(options.output))
-            .pipe(new notifications().message('Browserified!'));
+        var b = browserify(src, options);
+
+        if (config.watchify) {
+            b = watchify(b);
+
+            b.on('update', function() {
+                console.log('bundling');
+                bundle(b);
+            });
+        }
+
+        return bundle(b);
     });
 
-    this.registerWatcher('browserify', options.srcDir + '/**/*.js');
+    this.registerWatcher('browserify', options.srcDir + '/**/*.js', config.watchify ? 'nowatch' : 'default');
 
     return this.queueTask('browserify');
 });
+
+elixir.extend('watchify', function(src, options) {
+
+    var config = this,
+        srcPaths,
+        tasksToRun;
+
+    gulp.task('watchify', ['watch'], function() {
+        srcPaths = config.watchers.nowatch;
+        tasksToRun = _.intersection(config.tasks, _.keys(srcPaths).concat('copy'));
+        config.watchify = true;
+
+        inSequence.apply(this, ['browserify']);
+    });
+
+    return this.queueTask('watchify');
+})

--- a/index.js
+++ b/index.js
@@ -12,9 +12,14 @@ var gulp = require('gulp'),
     watchify = require('watchify'),
     _  = require('underscore');
 
+function snake_case(file) {
+    return 'browserify_' + file.split('.')[0].split('/').join('_');
+}
+
 elixir.extend('browserify', function (src, options) {
 
     var config = this,
+        taskName = snake_case(src),
         defaultOptions = {
             debug:         ! config.production,
             rename:        null,
@@ -27,7 +32,7 @@ elixir.extend('browserify', function (src, options) {
     options = _.extend(defaultOptions, options);
     src = "./" + utilities.buildGulpSrc(src, options.srcDir);
 
-    gulp.task('browserify', function () {
+    gulp.task(taskName, function () {
 
         var onError = function(e) {
             new notifications().error(e, 'Browserify Compilation Failed!');
@@ -51,7 +56,6 @@ elixir.extend('browserify', function (src, options) {
             b = watchify(b);
 
             b.on('update', function() {
-                console.log('bundling');
                 bundle(b);
             });
         }
@@ -59,9 +63,9 @@ elixir.extend('browserify', function (src, options) {
         return bundle(b);
     });
 
-    this.registerWatcher('browserify', options.srcDir + '/**/*.js', config.watchify ? 'nowatch' : 'default');
+    this.registerWatcher(taskName, options.srcDir + '/**/*.js', config.watchify ? 'nowatch' : 'default');
 
-    return this.queueTask('browserify');
+    return this.queueTask(taskName);
 });
 
 elixir.extend('watchify', function(src, options) {
@@ -75,7 +79,7 @@ elixir.extend('watchify', function(src, options) {
         tasksToRun = _.intersection(config.tasks, _.keys(srcPaths).concat('copy'));
         config.watchify = true;
 
-        inSequence.apply(this, ['browserify']);
+        inSequence.apply(this, tasksToRun);
     });
 
     return this.queueTask('watchify');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "gulp-uglify": "^1.0.1",
     "underscore": "^1.7.0",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.0.0"
+    "vinyl-source-stream": "^1.0.0",
+    "watchify": "~2.4.0",
+    "run-sequence": "~1.0.2"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
Watchify
-----------
Added watchify as a separate task that can be registered using the syntax

```javascript
elixir(function(mix) {
    mix.browserify("bootstrap.js")
        .watchify();
});
```

This adds a gulp task `watchify` that should be used instead of `watch`. The `watchify` task depends on the `watch` task so all registered watchers are run regardless.

This does not break bc. If you use the `watch` task, file changes will be watched using `gulp.watch`.

Multiple bundles
----------------------

This PR also addresses multiple bundles with elixir-browserify.

```javascript
elixir(function(mix) {
    mix.browserify("bootstrap.js")
        .browserify("other_module.js")
        .browserify("component/filereader.js", {
            debug : true,
            transforms : ["debowerify"]
        })
        .watchify();
});
```

Tasks are created using a snake cased path and filename without the .js extension.

`component/filereader.js` becomes a task named `browserify_component_filereader`.

