### PR TITLE
Updated multi bundles and watchify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+/.idea

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ elixir(function(mix) {
     });
 });
 ```
+#### Watchify
+```javascript
+var elixir = require('laravel-elixir');
+require('laravel-elixir-browserify');
+
+elixir(function(mix) {
+    mix.browserify("bootstrap.js")
+        .watchify();
+});
+```
+**Note** instead of running the `watch` task, you will now run `watchify`. Elixir's watch task is a dependency of watchify and will also be run.
 
 ## Changelog
 __0.6.0__

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var gulp = require('gulp'),
     elixir = require('laravel-elixir'),
+    config = elixir.config,
+    inSequence = require('run-sequence'),
     utilities = require('laravel-elixir/ingredients/commands/Utilities'),
     notifications = require('laravel-elixir/ingredients/commands/Notification'),
     gulpIf = require('gulp-if'),
@@ -8,46 +10,94 @@ var gulp = require('gulp'),
     source = require('vinyl-source-stream'),
     buffer = require('vinyl-buffer'),
     browserify = require('browserify'),
+    watchify = require('watchify'),
     _  = require('underscore');
 
-elixir.extend('browserify', function (src, options) {
+/**
+ * Create the Gulp task.
+ *
+ * @return {void}
+ */
+var buildTask = function() {
+    var stream;
 
-    var config = this,
-        defaultOptions = {
-            debug:         ! config.production,
-            rename:        null,
-            srcDir:        config.assetsDir + 'js',
-            output:        config.jsOutput,
-            transform:     [],
-            insertGlobals: false,
-        };
-
-    options = _.extend(defaultOptions, options);
-    src = "./" + utilities.buildGulpSrc(src, options.srcDir);
-
-    gulp.task('browserify', function () {
+    gulp.task('browserify', function(callback) {
 
         var onError = function(e) {
             new notifications().error(e, 'Browserify Compilation Failed!');
             this.emit('end');
         };
 
-        var browserified = function(filename) {
-            var b = browserify(filename, options);
-            
-            return b.bundle();
-        };
+        var bundle = function(b, instance) {
+            return b.bundle()
+                .on('error', onError)
+                .pipe(source(instance.src.split("/").pop()))
+                .pipe(buffer())
+                .pipe(gulpIf(!instance.options.debug, uglify()))
+                .pipe(gulpIf(typeof instance.options.rename === 'string', rename(instance.options.rename)))
+                .pipe(gulp.dest(instance.options.output))
+                .pipe(new notifications().message('Browserified!'));
+        }
 
-        return browserified(src).on('error', onError)
-            .pipe(source(src.split("/").pop()))
-            .pipe(buffer())
-            .pipe(gulpIf(! options.debug, uglify()))
-            .pipe(gulpIf(typeof options.rename === 'string', rename(options.rename)))
-            .pipe(gulp.dest(options.output))
-            .pipe(new notifications().message('Browserified!'));
+        config.toBrowserify.forEach(function(instance) {
+            var b = browserify(instance.src, instance.options);
+
+            if (config.watchify) {
+                b = watchify(b);
+
+                b.on('update', function() {
+                    bundle(b, instance);
+                });
+            }
+
+            stream = bundle(b, instance);
+        });
+
+        return stream;
+    });
+}
+
+/**
+ * Create elixir extension
+ */
+elixir.extend('browserify', function (src, options) {
+
+    if (!_.isArray(config.toBrowserify))
+        config.toBrowserify = [];
+
+    options = _.extend({
+        debug:         ! config.production,
+        rename:        null,
+        srcDir:        config.assetsDir + 'js',
+        output:        config.jsOutput,
+        transform:     [],
+        insertGlobals: false
+    }, options);
+
+    config.toBrowserify.push({
+        src : "./" + utilities.buildGulpSrc(src, options.srcDir),
+        options: options
     });
 
-    this.registerWatcher('browserify', options.srcDir + '/**/*.js');
+    buildTask();
 
-    return this.queueTask('browserify');
+    this.registerWatcher('browserify', options.srcDir + '/**/*.js', config.watchify ? 'nowatch' : 'default');
+
+    return config.queueTask('browserify');
 });
+
+/**
+ * Create elixir extension for Watchify command
+ */
+elixir.extend('watchify', function(src, options) {
+
+    var config = this;
+
+    gulp.task('watchify', ['watch'], function() {
+        config.watchify = true;
+
+        inSequence.apply(this, ['browserify']);
+    });
+
+    return this.queueTask('watchify');
+})

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ elixir.extend('browserify', function (src, options) {
 
     this.registerWatcher('browserify', options.srcDir + '/**/*.js', config.watchify ? 'nowatch' : 'default');
 
-    return config.queueTask('browserify');
+    return this.queueTask('browserify');
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "gulp-uglify": "^1.0.1",
     "underscore": "^1.7.0",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.0.0"
+    "vinyl-source-stream": "^1.0.0",
+    "watchify": "~2.4.0",
+    "run-sequence": "~1.0.2"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
UPDATED to remove multiple task creation as a solution to Mutliple Bundles.

Watchify
-----------
Added watchify as a separate task that can be registered using the syntax

```javascript
elixir(function(mix) {
    mix.browserify("bootstrap.js")
        .watchify();
});
```

This adds a gulp task `watchify` that should be used instead of `watch`. The `watchify` task depends on the `watch` task so all registered watchers are run regardless.

This does not break bc. If you use the `watch` task, file changes will be watched using `gulp.watch`.

Multiple bundles
----------------------

This PR also addresses multiple bundles with elixir-browserify.

```javascript
elixir(function(mix) {
    mix.browserify("bootstrap.js")
        .browserify("other_module.js")
        .browserify("component/filereader.js", {
            debug : true,
            transforms : ["debowerify"]
        })
        .watchify();
});
```

Tasks are added to an array that is then looped over providing individual browserify instances for each time it is called.