### PR TITLE
Added watchify as separated task

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ var buildTask = function() {
         config.toBrowserify.forEach(function(instance) {
             var b = browserify(instance.src, instance.options);
 
-            if (config.watchify) {
+            if (config.useWatchify) {
                 b = watchify(b);
 
                 b.on('update', function() {
@@ -80,22 +80,19 @@ elixir.extend('browserify', function (src, options) {
 
     buildTask();
 
-    this.registerWatcher('browserify', options.srcDir + '/**/*.js', config.watchify ? 'nowatch' : 'default');
+    this.registerWatcher('browserify', options.srcDir + '/**/*.js', config.useWatchify ? 'nowatch' : 'default');
 
     return this.queueTask('browserify');
 });
 
 /**
- * Create elixir extension for Watchify command
+ * Watching changes with watchify
  */
-elixir.extend('watchify', function() {
-    var config = this;
+gulp.task('watchify', function() {
+    config.useWatchify = true;
 
-    gulp.task('watchify', ['watch'], function() {
-        config.watchify = true;
+    srcPaths = config.watchers.default;
+    tasksToRun = _.intersection(config.tasks, _.keys(srcPaths).concat('copy'));
 
-        inSequence.apply(this, ['browserify']);
-    });
-
-    return this.queueTask('watchify');
+    inSequence.apply(this, tasksToRun.concat('watch-assets'));
 });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "underscore": "^1.7.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0",
-    "watchify": "~2.4.0",
+    "watchify": "~2.6.0",
     "run-sequence": "~1.0.2"
   },
   "devDependencies": {},


### PR DESCRIPTION
Referring to the #21, watchify is not a standard task - it itself does noting. This pull request removed elixir `watchify` function but leaves `gulp watchify` task. Currently it's possible to run all elixir task **once**, run elixir task with **standard watch** and run elixir tasks with standard watchers and watchify for browserify.

Breaking change: remove 'watchify()' elixir function.

