### PR TITLE
Removed excessive notices being recursively generated

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,7 @@ var initializePlugin = function(taskName) {
                     .pipe(buffer())
                     .pipe(gulpIf(!instance.options.debug, uglify()))
                     .pipe(gulpIf(typeof instance.options.rename === 'string', rename(instance.options.rename)))
-                    .pipe(gulp.dest(instance.options.output))
-                    .pipe(new notifications().message('Browserified!'));
+                    .pipe(gulp.dest(instance.options.output));
             };
 
             config.toBrowserify.forEach(function(instance) {
@@ -53,7 +52,7 @@ var initializePlugin = function(taskName) {
                 stream = bundle(b, instance);
             });
 
-            return stream;
+            return stream.pipe(new notifications().message('Browserified!'));;
         });
     };
 


### PR DESCRIPTION
Removed the notification from the bundle function and piped it once from the returned stream item. This triggers a single "browserified!" notification rather than `n+1` notifications for each time it is run.